### PR TITLE
build.sbt improvements

### DIFF
--- a/src/main/g8/build.sbt
+++ b/src/main/g8/build.sbt
@@ -1,5 +1,3 @@
-import Dependencies._
-
 lazy val root = (project in file(".")).
   settings(
     inThisBuild(List(

--- a/src/main/g8/build.sbt
+++ b/src/main/g8/build.sbt
@@ -6,10 +6,10 @@ lazy val root = (project in file(".")).
       version      := "0.1.0-SNAPSHOT",
       javacOptions ++= Seq("-source", "1.8", "-target", "1.8"),
       // For project with only Java sources. In order to compile Scala sources, remove the following two lines.
-      crossPaths := false,
-      autoScalaLibrary := false
+      crossPaths := false
     )),
     name := "Hello",
+    autoScalaLibrary := false,
     libraryDependencies ++= Seq(
       "junit" % "junit" % "4.12" % "test",
       "com.novocode" % "junit-interface" % "0.11" % "test"

--- a/src/main/g8/project/Dependencies.scala
+++ b/src/main/g8/project/Dependencies.scala
@@ -1,5 +1,0 @@
-import sbt._
-
-object Dependencies {
-  lazy val scalaTest = "org.scalatest" %% "scalatest" % "3.0.1"
-}


### PR DESCRIPTION
* removed unneccessary Dependencies.scala file
* actually disabled `autoScalaLibrary` (with previous settings I was seeing Scala library downloaded anyway)